### PR TITLE
Improve issue fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Yearn Open Issues Browser
 
-- Check it out: [contribute.yearn.rocks](https://contribute.yearn.rocks)
+- Live Page: [contribute.yearn.rocks](https://contribute.yearn.rocks)
 
-### Credits
+## Quickstart
+
+- Clone this repo and open `index.html` to run this project locally
+
+## Credits
 
 - Forked from: [TRTL Issues](https://github.com/turtlecoin/trtl-issues)

--- a/dist/js/main.js
+++ b/dist/js/main.js
@@ -64,9 +64,12 @@ function createCommentSVG() {
 
 async function fetchRepoIssues(repo) {
     const issueRes = await fetch(`https://api.github.com/repos/${repo.full_name}/issues`);
-    let issues = await issueRes.json();
 
-    issues = (issues || []).filter((i) => !i.pull_request);
+    let issues = issueRes.ok 
+        ? await issueRes.json()
+        : []
+
+    issues = issues.filter((i) => !i.pull_request);
 
     if (issues.length === 0) {
         return;
@@ -191,7 +194,7 @@ async function loadGithubIssues() {
         bodySideBar.style.display = 'block';
 		$('[data-toggle="tooltip"]').tooltip();
     } catch (err) {
-        alert(`Failed to fetch data: ${err.toString()}`);
+        console.error(`Failed to fetch data: ${err.toString()}`);
     }
 }
 


### PR DESCRIPTION
This will make the page stop throwing alerts on errors (alerts interrupt all browser navigation, weird UX) and also fixed the error throwing when fetching fails

There is an issue here that I don't know how to fix easily which is the page furiously requests github for repos and even when I tried adding some timeout I was constantly getting rate-limmited by github API and issues didn't load, github doesn't expose a route to fetch multiple repost in 1 request from what I looked :(